### PR TITLE
Webpack dev server needs to be restarted after 5 Elm compile errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function() {
 
     var compilation = elmCompiler.compileToString(input, options)
       .then(function(v) { runningInstances -= 1; return { kind: 'success', result: v }; })
-      .catch(function(v) { return { kind: 'error', error: v }; });
+      .catch(function(v) { runningInstances -= 1; return { kind: 'error', error: v }; });
 
     promises.push(compilation);
 


### PR DESCRIPTION
I found that my webpack dev server kept hanging, and tracked it down to this bug. The then() branch of the compileToString() promise was releasing a running process slot, but the catch() branch was not.
