### PR TITLE
Watch individual Elm source files for changes, not source directories

### DIFF
--- a/test/loader.js
+++ b/test/loader.js
@@ -32,7 +32,6 @@ var mock = function (source, query, opts, callback, watchMode, cwd) {
   var emittedError;
   var emittedWarning;
   var addedDependencies = [];
-  var addedDirDependencies = [];
 
   var result = {
     loaders: [],
@@ -49,9 +48,7 @@ var mock = function (source, query, opts, callback, watchMode, cwd) {
     emittedWarning: function () { return emittedWarning; },
 
     addDependency: function (dep) { addedDependencies.push(dep); },
-    addContextDependency: function(dir) { addedDirDependencies.push(dir); },
     addedDependencies: function () { return addedDependencies; },
-    addedDirDependencies: function() { return addedDirDependencies; },
 
     cacheable: function () {},
 
@@ -120,7 +117,6 @@ describe('async mode', function () {
     process.argv = [];
     var callback = function () {
       assert.equal(context.addedDependencies().length, 0);
-      assert.equal(context.addedDirDependencies().length, 0);
       done();
     };
 
@@ -135,10 +131,8 @@ describe('async mode', function () {
 
     process.argv = [ "--watch" ];
     var callback = function () {
-      assert.equal(context.addedDependencies().length, 1);
       assert.include(context.addedDependencies(), elmPackage);
-      assert.equal(context.addedDirDependencies().length, 1);
-      assert.include(context.addedDirDependencies(), fixturesDir);
+      assert.include(context.addedDependencies(), goodDependency);
       done();
     };
 


### PR DESCRIPTION
elm-webpack-loader advertises itself as being cacheable.

Webpack caching requires all dependencies to be added with `addDependency`, not `addContextDependency`. In order to allow for this loader’s output to be cached between runs in watch mode, therefore, we must switch to adding individual Elm source files as dependencies, rather than simply adding entire Elm source directories as context dependencies.

From https://webpack.github.io/docs/loaders.html#cacheable:

> `cacheable`
>
> ```
> cacheable(flag = true: boolean)
> ```
> Make this loader result cacheable. By default it’s not cacheable.
> 
> A cacheable loader must have a deterministic result, when inputs and dependencies haven’t changed. This means the loader shouldn’t have other dependencies than specified with `this.addDependency`. Most loaders are deterministic and cacheable.