### PR TITLE
Fix small typo of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ will cause the compiler to look for **all** elm source files in the specified di
 
 #### maxInstances (default 4)
 
-You can add `cache=true` to the loader:
+You can add `maxInstances=8` to the loader:
 
 ```js
   ...


### PR DESCRIPTION
I fixed a small typo of documentation. Did I got your intend correctly?

```diff
@@ -51,7 +51,7 @@ will cause the compiler to look for **all** elm source files in the ...
 #### maxInstances (default 4)

-You can add `cache=true` to the loader:
+You can add `maxInstances=8` to the loader:
 
 ```js
   ...
```