### PR TITLE
Add ForceWatch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ new files won't be picked up and so won't be watched until you restart webpack.
 
 This flag doesn't matter if you don't use watch mode.
 
+#### ForceWatch (default false)
+
+This loader will infer if you are running webpack in watch mode by checking
+the webpack arguments. If you are running webpack programmatically and
+wants to force this behaviour you can add `forceWatch=true` to the loader:
+
+```js
+  ...
+  loader: 'elm-webpack?forceWatch=true'
+  ...
+```
 
 #### Upstream options
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var alreadyCompiledFiles = [];
 
 var defaultOptions = {
   cache: false,
+  forceWatch: false,
   yes: true
 };
 
@@ -95,7 +96,7 @@ module.exports = function() {
 
   // we only need to track deps if we are in watch mode
   // otherwise, we trust elm to do it's job
-  if (isInWatchMode()){
+  if (options.forceWatch || isInWatchMode()){
     // we can do a glob to track deps we care about if cwd is set
     if (typeof options.cwd !== "undefined" && options.cwd !== null){
       // watch elm-package.json
@@ -119,6 +120,8 @@ module.exports = function() {
 
     promises.push(dependencies);
   }
+
+  delete options.forceWatch
 
   var maxInstances = options.maxInstances;
 


### PR DESCRIPTION
This fixes #84 by adding a forceWatch flag to trigger the webpack watch behaviour regardless of how webpack is run.

I've tried to add tests to it, but there's something going on with the test suite where it mysteriously hangs with new test that touches the mocked context. Even duplicating the current watch tests trigger this behaviour.
