### PR TITLE
ESLint integration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+elm-stuff/
+dist/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -42,7 +42,10 @@ rules:
   no-caller: 'error'
   no-div-regex: 'error'
   no-else-return: 'error'
-  no-empty-function: 'error'
+  no-empty-function:
+    - 'error'
+    - allow:
+      - 'arrowFunctions'
   no-eval: 'error'
   no-extend-native: 'error'
   no-extra-bind: 'error'
@@ -202,7 +205,6 @@ rules:
   new-parens: 'error'
   newline-after-var: 'error'
   newline-before-return: 'error'
-  newline-per-chained-call: 'error'
   no-array-constructor: 'error'
   no-multi-assign: 'error'
   no-multiple-empty-lines:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -273,6 +273,7 @@ rules:
 
 
   ### ECMAScript 6 ###
+
   arrow-body-style:
     - 'error'
     - 'as-needed'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,307 @@
+root: true
+
+extends:
+  - 'eslint:recommended'
+
+env:
+  es6: true
+  node: true
+
+rules:
+  ### POSSIBLE ERRORS ###
+
+  no-compare-neg-zero: 'error'
+  no-console: 'off'
+  no-extra-parens: 'error'
+  no-template-curly-in-string: 'error'
+  no-unsafe-negation: 'error'
+  valid-typeof: 'error'
+
+
+  ### BEST PRACTICES ###
+
+  accessor-pairs: 'error'
+  array-callback-return: 'error'
+  block-scoped-var: 'error'
+  consistent-return: 'error'
+  curly: 'error'
+  default-case: 'error'
+  dot-location:
+    - 'error'
+    - 'property'
+  dot-notation:
+    - 'error'
+    - allowKeywords: true
+  eqeqeq:
+      - 'error'
+      - 'always'
+      - null: 'ignore'
+  guard-for-in: 'error'
+  no-alert: 'error'
+  no-caller: 'error'
+  no-div-regex: 'error'
+  no-else-return: 'error'
+  no-empty-function: 'error'
+  no-eval: 'error'
+  no-extend-native: 'error'
+  no-extra-bind: 'error'
+  no-extra-label: 'error'
+  no-floating-decimal: 'error'
+  no-global-assign: 'error'
+  no-implicit-coercion:
+    - 'error'
+    - boolean: false
+      number: true
+      string: true
+  no-implied-eval: 'error'
+  no-invalid-this: 'error'
+  no-iterator: 'error'
+  no-labels: 'error'
+  no-lone-blocks: 'error'
+  no-loop-func: 'error'
+  no-magic-numbers:
+    - 'error'
+    - ignoreArrayIndexes: true
+      ignore:
+      - 1
+  no-multi-spaces: 'error'
+  no-multi-str: 'error'
+  no-new: 'error'
+  no-new-func: 'error'
+  no-new-wrappers: 'error'
+  no-octal-escape: 'error'
+  no-param-reassign: 'error'
+  no-proto: 'error'
+  no-return-assign:
+    - 'error'
+    - 'always'
+  no-return-await: 'error'
+  no-self-compare: 'error'
+  no-sequences: 'error'
+  no-throw-literal: 'error'
+  no-unused-expressions: 'error'
+  no-useless-call: 'error'
+  no-useless-concat: 'error'
+  no-useless-escape: 'error'
+  no-useless-return: 'error'
+  no-void: 'error'
+  no-warning-comments: 'error'
+  no-with: 'error'
+  radix: 'error'
+  require-await: 'error'
+  yoda: 'error'
+
+
+  ### STRICT MODE ###
+
+  strict: 'error'
+
+
+  ### VARIABLES ###
+
+  init-declarations:
+    - 'error'
+    - 'always'
+  no-catch-shadow: 'error'
+  no-label-var: 'error'
+  no-restricted-globals: 'error'
+  no-shadow: 'error'
+  no-shadow-restricted-names: 'error'
+  no-undef-init: 'error'
+  no-undefined: 'error'
+  no-use-before-define:
+    - 'error'
+    - 'nofunc'
+
+
+  ### NODE.JS ###
+
+  callback-return:
+    - 'error'
+    - - 'done'
+      - 'cb'
+      - 'send.error'
+      - 'send.success'
+  handle-callback-err: 'error'
+  no-new-require: 'error'
+  no-path-concat: 'error'
+  no-process-exit: 'error'
+
+
+  ### STYLISTIC ISSUES ###
+
+  array-bracket-spacing:
+    - 'error'
+    - 'always'
+    - objectsInArrays: false
+      arraysInArrays: false
+  block-spacing:
+    - 'error'
+    - 'always'
+  brace-style:
+    - 'error'
+    - '1tbs'
+  camelcase:
+    - 'error'
+    - properties: 'never'
+  comma-dangle:
+    - 'error'
+    - 'never'
+  comma-spacing:
+    - 'error'
+    - before: false
+      after: true
+  comma-style:
+    - 'error'
+    - 'last'
+  computed-property-spacing:
+    - 'error'
+    - 'always'
+  consistent-this:
+    - 'error'
+    - 'self'
+  eol-last:
+    - 'error'
+    - 'always'
+  func-call-spacing:
+    - 'error'
+    - 'never'
+  func-name-matching: 'error'
+  func-names: 'error'
+  indent:
+    - 'error'
+    - 2
+    - SwitchCase: 1
+  key-spacing:
+    - 2
+    - beforeColon: false
+      afterColon: true
+  keyword-spacing: 'error'
+  linebreak-style:
+    - 2
+    - 'unix'
+  max-depth:
+    - 'error'
+    - 4
+  max-len:
+    - 'error'
+    - 120
+  max-nested-callbacks:
+    - 'error'
+    - 4
+  max-statements-per-line:
+    - 'error'
+    - max: 1
+  new-cap:
+    - 'error'
+    - capIsNew: false
+  new-parens: 'error'
+  newline-after-var: 'error'
+  newline-per-chained-call: 'error'
+  no-array-constructor: 'error'
+  no-multi-assign: 'error'
+  no-multiple-empty-lines:
+    - 'error'
+    - max: 2
+  no-nested-ternary: 'error'
+  no-new-object: 'error'
+  no-plusplus: 'error'
+  no-tabs: 'error'
+  no-trailing-spaces: 'error'
+  no-unneeded-ternary: 'error'
+  no-whitespace-before-property: 'error'
+  nonblock-statement-body-position:
+    - 'error'
+    - 'below'
+  object-curly-newline:
+    - 'error'
+    - ObjectExpression:
+        multiline: true
+        minProperties: 1
+      ObjectPattern:
+        multiline: true
+  object-curly-spacing:
+    - 'error'
+    - 'always'
+    - arraysInObjects: false
+      objectsInObjects: false
+  object-property-newline: 'error'
+  one-var:
+    - 'error'
+    - uninitialized: 'never'
+      initialized: 'never'
+  operator-assignment:
+    - 'error'
+    - 'always'
+  operator-linebreak:
+    - 'error'
+    - 'before'
+  padded-blocks:
+    - 'error'
+    - 'never'
+  quote-props:
+    - 'error'
+    - 'as-needed'
+  quotes:
+    - 'error'
+    - 'single'
+    - avoidEscape: true
+  semi:
+    - 'error'
+    - 'always'
+  semi-spacing:
+    - 'error'
+    - before: false
+      after: true
+  space-before-blocks:
+    - 'error'
+    - 'always'
+  space-before-function-paren:
+    - 'error'
+    - 'never'
+  space-in-parens:
+    - 'error'
+    - 'never'
+  space-infix-ops: 'error'
+  space-unary-ops: 'error'
+  spaced-comment:
+    - 'error'
+    - 'always'
+    - exceptions:
+      - '*'
+      - '-'
+
+
+  ### ECMAScript 6 ###
+  arrow-body-style:
+    - 'error'
+    - 'as-needed'
+  arrow-spacing: 'error'
+  generator-star-spacing:
+    - 'error'
+    - before: false
+      after: true
+  no-class-assign: 'error'
+  no-const-assign: 'error'
+  no-duplicate-imports: 'error'
+  no-useless-computed-key: 'error'
+  no-useless-constructor: 'error'
+  no-useless-rename: 'error'
+  no-var: 'error'
+  prefer-arrow-callback:
+    - 'error'
+    - allowNamedFunctions: true
+  prefer-const:
+    - 'error'
+    - destructuring: 'any'
+  prefer-destructuring: 'error'
+  prefer-rest-params: 'error'
+  prefer-spread: 'error'
+  prefer-template: 'error'
+  rest-spread-spacing:
+    - 'error'
+    - 'never'
+  template-curly-spacing: 'error'
+  yield-star-spacing:
+    - 'error'
+    - 'after'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,6 +15,7 @@ rules:
   no-extra-parens: 'error'
   no-template-curly-in-string: 'error'
   no-unsafe-negation: 'error'
+  valid-jsdoc: 'error'
   valid-typeof: 'error'
 
 
@@ -64,6 +65,8 @@ rules:
     - ignoreArrayIndexes: true
       ignore:
       - 1
+      - 0
+      - -1
   no-multi-spaces: 'error'
   no-multi-str: 'error'
   no-new: 'error'
@@ -172,6 +175,7 @@ rules:
     - 'error'
     - 2
     - SwitchCase: 1
+      MemberExpression: 1
   key-spacing:
     - 2
     - beforeColon: false
@@ -197,6 +201,7 @@ rules:
     - capIsNew: false
   new-parens: 'error'
   newline-after-var: 'error'
+  newline-before-return: 'error'
   newline-per-chained-call: 'error'
   no-array-constructor: 'error'
   no-multi-assign: 'error'
@@ -275,6 +280,9 @@ rules:
   ### ECMAScript 6 ###
 
   arrow-body-style:
+    - 'error'
+    - 'as-needed'
+  arrow-parens:
     - 'error'
     - 'as-needed'
   arrow-spacing: 'error'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+npm-debug.log
 elm-stuff/
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 env:
   matrix:
     - ELM_VERSION=0.18 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.18 TARGET_NODE_VERSION=4.2
+    - ELM_VERSION=0.18 TARGET_NODE_VERSION=6.0
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,5 @@ install:
   - npm install
 
 script:
+  - npm run lint
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   ELM_VERSION: 0.18
   matrix:
-  - nodejs_version: "5.0"
-  - nodejs_version: "4.2"
+  - nodejs_version: "7.0"
+  - nodejs_version: "6.0"
 
 platform:
   - x86

--- a/example/.eslintrc
+++ b/example/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "env": {
-    "browser": true
-  }
-}

--- a/example/.eslintrc.yml
+++ b/example/.eslintrc.yml
@@ -1,0 +1,3 @@
+env:
+  browser: true
+  node: false

--- a/example/.eslintrc.yml
+++ b/example/.eslintrc.yml
@@ -1,3 +1,9 @@
 env:
   browser: true
   node: false
+  commonjs: true
+
+rules:
+  strict:
+    - 'error'
+    - 'never'

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,4 @@
-'use strict';
-
 require('./index.html');
-var Elm = require('./Main');
+const Elm = require('./Main');
 
 Elm.Main.embed(document.getElementById('main'));

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -7,8 +7,8 @@ module.exports = {
   },
 
   resolve: {
-    modulesDirectories: ['node_modules'],
-    extensions: ['', '.js', '.elm']
+    modulesDirectories: [ 'node_modules' ],
+    extensions: [ '', '.js', '.elm' ]
   },
 
   module: {
@@ -20,7 +20,7 @@ module.exports = {
       },
       {
         test: /\.elm$/,
-        exclude: [/elm-stuff/, /node_modules/],
+        exclude: [ /elm-stuff/, /node_modules/ ],
         loader: '../../index.js'
       }
     ],

--- a/index.js
+++ b/index.js
@@ -1,168 +1,227 @@
 'use strict';
 
-var fs = require("fs")
-var path = require('path')
-var loaderUtils = require('loader-utils');
-var elmCompiler = require('node-elm-compiler');
-var yargs = require('yargs');
+const fs = require('fs');
+const path = require('path');
+const loaderUtils = require('loader-utils');
+const elmCompiler = require('node-elm-compiler');
+const yargs = require('yargs');
 
-var cachedDependencies = [];
-var cachedDirDependencies = [];
-var runningInstances = 0;
-var alreadyCompiledFiles = [];
 
-var defaultOptions = {
+const RUNNING_INSTANCE_INTERVAL = 200;
+const cachedDependencies = [];
+let cachedDirDependencies = [];
+let runningInstances = 0;
+const alreadyCompiledFiles = [];
+
+const defaultOptions = {
   cache: false,
   forceWatch: false,
   yes: true
 };
 
-var getInput = function() {
+/**
+ * @this LoaderContext
+ *
+ * @return {String} path to resource
+ */
+function getInput() {
   return this.resourcePath;
-};
+}
 
-var getOptions = function() {
-  var globalOptions = this.options.elm || {};
-  var loaderOptions = loaderUtils.getOptions(this) || {};
+/**
+ * @this LoaderContext
+ *
+ * @return {Object} loader options
+ */
+function getOptions() {
+  const globalOptions = this.options.elm || {};
+  const loaderOptions = loaderUtils.getOptions(this) || {};
+
   return Object.assign({
     emitWarning: this.emitWarning
   }, defaultOptions, globalOptions, loaderOptions);
-};
+}
 
-var _addDependencies = function(dependency) {
+/**
+ * @this LoaderContext
+ * @param {String} dependency path to dependency
+ *
+ * @return {void}
+ */
+function _addDependencies(dependency) {
   cachedDependencies.push(dependency);
   this.addDependency(dependency);
-};
+}
 
-var _addDirDependency = function(dirs){
-  // only keep unique dirs
-  dirs = dirs.filter(function(dir){
-    return cachedDirDependencies.indexOf(dir) === -1;
-  });
+/**
+ * @this LoaderContext
+ * @param {String[]} dirs list of paths to dependencies
+ *
+ * @return {void}
+ */
+function _addDirDependency(dirs) {
+  const uniqueDirs = dirs.filter(dir => cachedDirDependencies.indexOf(dir) === -1);
 
-  cachedDirDependencies = cachedDirDependencies.concat(dirs);
-  dirs.forEach(this.addContextDependency.bind(this));
-};
+  cachedDirDependencies = cachedDirDependencies.concat(uniqueDirs);
+  uniqueDirs.forEach(this.addContextDependency.bind(this));
+}
 
-/* Figures out if webpack has been run in watch mode
-    This currently means either that the `watch` command was used
-    Or it was run via `webpack-dev-server`
-*/
-var isInWatchMode = function(){
+/**
+ * Figures out if webpack has been run in watch mode
+ * This currently means either that the `watch` command was used
+ * Or it was run via `webpack-dev-server`
+ *
+ * @return {Boolean} watch mode was enabled
+ */
+function isInWatchMode() {
   // parse the argv given to run this webpack instance
-  var argv = yargs(process.argv)
-      .alias('w', 'watch')
-      .argv;
-
-  var hasWatchArg = typeof argv.watch !== "undefined" && argv.watch;
-
-  var hasWebpackDevServer = Array.prototype.filter.call(process.argv, function (arg) {
-    return arg.indexOf('webpack-dev-server') !== -1;
-  }).length > 0;
+  const { argv } = yargs(process.argv).alias('w', 'watch');
+  const hasWatchArg = typeof argv.watch !== 'undefined' && argv.watch;
+  const hasWebpackDevServer = Array.prototype.filter.call(
+    process.argv,
+    arg => arg.indexOf('webpack-dev-server') !== -1
+  ).length > 0;
 
   return hasWebpackDevServer || hasWatchArg;
-};
+}
 
-/* Takes a working dir, tries to read elm-package.json, then grabs all the modules from in there
-*/
-var filesToWatch = function(cwd){
-  var readFile = fs.readFileSync(path.join(cwd, "elm-package.json"), 'utf8');
-  var elmPackage = JSON.parse(readFile);
-
-  var paths = elmPackage["source-directories"].map(function(dir){
-    return path.join(cwd, dir);
-  });
+/**
+ * Takes a working dir, tries to read elm-package.json,
+ * then grabs all the modules from in there
+ *
+ * @param {String} cwd path to cwd
+ *
+ * @return {String[]} list of paths to watched directories
+ */
+function filesToWatch(cwd) {
+  const readFile = fs.readFileSync(path.join(cwd, 'elm-package.json'), 'utf8');
+  const elmPackage = JSON.parse(readFile);
+  const paths = elmPackage[ 'source-directories' ].map(dir => path.join(cwd, dir));
 
   return paths;
-};
+}
 
-module.exports = function() {
-  this.cacheable && this.cacheable();
+/**
+ * @this LoaderContext
+ *
+ * @return {void}
+ */
+module.exports = function ElmWebpackLoader() {
+  if (this.cacheable) {
+    this.cacheable();
+  }
 
-  var callback = this.async();
+  const callback = this.async();
+
   if (!callback) {
-    throw 'elm-webpack-loader currently only supports async mode.';
+    throw new Error('elm-webpack-loader currently only supports async mode.');
   }
 
   // bind helper functions to `this`
-  var addDependencies = _addDependencies.bind(this);
-  var addDirDependency = _addDirDependency.bind(this);
-  var emitError = this.emitError.bind(this);
+  const addDependencies = _addDependencies.bind(this);
+  const addDirDependency = _addDirDependency.bind(this);
+  const emitError = this.emitError.bind(this);
 
-  var input = getInput.call(this);
-  var options = getOptions.call(this);
+  const input = getInput.call(this);
+  const options = getOptions.call(this);
 
-  var promises = [];
+  const promises = [];
 
   // we only need to track deps if we are in watch mode
   // otherwise, we trust elm to do it's job
-  if (options.forceWatch || isInWatchMode()){
+  if (options.forceWatch || isInWatchMode()) {
     // we can do a glob to track deps we care about if cwd is set
-    if (typeof options.cwd !== "undefined" && options.cwd !== null){
+    if (typeof options.cwd !== 'undefined' && options.cwd !== null) {
       // watch elm-package.json
-      var elmPackage = path.join(options.cwd, "elm-package.json");
+      const elmPackage = path.join(options.cwd, 'elm-package.json');
+      const dirs = filesToWatch(options.cwd);
+
       addDependencies(elmPackage);
-      var dirs = filesToWatch(options.cwd);
       // watch all the dirs in elm-package.json
       addDirDependency.bind(this)(dirs);
     }
 
     // find all the deps, adding them to the watch list if we successfully parsed everything
     // otherwise return an error which is currently ignored
-    var dependencies = elmCompiler.findAllDependencies(input).then(function(dependencies){
-      // add each dependency to the tree
-      dependencies.map(addDependencies);
-      return { kind: 'success', result: true };
-    }).catch(function(v){
-      emitError(v);
-      return { kind: 'error', error: v };
-    })
+    const dependencies = elmCompiler.findAllDependencies(input)
+      .then(deps => {
+        // add each dependency to the tree
+        deps.map(addDependencies);
+
+        return {
+          kind: 'success',
+          result: true
+        };
+      })
+      .catch(v => {
+        emitError(v);
+
+        return {
+          kind: 'error',
+          error: v
+        };
+      });
 
     promises.push(dependencies);
   }
 
-  delete options.forceWatch
+  delete options.forceWatch;
 
-  var maxInstances = options.maxInstances;
+  let { maxInstances } = options;
 
-  if (typeof maxInstances === "undefined"){
+  if (typeof maxInstances === 'undefined') {
     maxInstances = 1;
   } else {
     delete options.maxInstances;
   }
 
-  var intervalId = setInterval(function(){
-    if (runningInstances > maxInstances) return;
+  const intervalId = setInterval(() => {
+    if (runningInstances > maxInstances) {
+      return;
+    }
+
     runningInstances += 1;
     clearInterval(intervalId);
 
     // If we are running in watch mode, and we have previously compiled
     // the current file, then let the user know that elm-make is running
     // and can be slow
-    if (alreadyCompiledFiles.indexOf(input) > -1){
+    if (alreadyCompiledFiles.indexOf(input) > -1) {
       console.log('Started compiling Elm..');
     }
 
-    var compilation = elmCompiler.compileToString(input, options)
-      .then(function(v) { runningInstances -= 1; return { kind: 'success', result: v }; })
-      .catch(function(v) { runningInstances -= 1; return { kind: 'error', error: v }; });
+    const compilation = elmCompiler.compileToString(input, options)
+      .then(v => {
+        runningInstances -= 1;
+
+        return {
+          kind: 'success',
+          result: v
+        };
+      })
+      .catch(v => {
+        runningInstances -= 1;
+
+        return {
+          kind: 'error',
+          error: v
+        };
+      });
 
     promises.push(compilation);
 
     Promise.all(promises)
-      .then(function(results) {
-        var output = results[results.length - 1]; // compilation output is always last
+      .then(results => {
+        const output = results[ results.length - 1 ]; // compilation output is always last
 
-        if (output.kind == 'success') {
+        if (output.kind === 'success') {
           alreadyCompiledFiles.push(input);
           callback(null, output.result);
         } else {
-          output.error.message = 'Compiler process exited with error ' + output.error.message;
+          output.error.message = `Compiler process exited with error ${output.error.message}`;
           callback(output.error);
         }
-      }).catch(function(err){
-        callback(err);
-      });
-
-  }, 200);
-}
+      })
+      .catch(callback);
+  }, RUNNING_INSTANCE_INTERVAL);
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/*.js"
+    "test": "mocha test/*.js",
+    "lint": "node_modules/.bin/eslint ."
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/*.js",
-    "lint": "node_modules/.bin/eslint ."
+    "lint": "eslint ."
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "eslint": "^3.17.0",
     "mocha": "3.0.2"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "env": {
-    "jasmine": true
-  }
-}

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  jasmine: true

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,2 +1,6 @@
 env:
   jasmine: true
+
+rules:
+  no-invalid-this: 'off'
+  no-magic-numbers: 'off'

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,178 +1,191 @@
-var path = require('path');
-var crypto = require('crypto');
-var assert = require('chai').assert;
-var compiler = require('node-elm-compiler');
-var loader = require('../index.js');
+'use strict';
 
-var fixturesDir = path.join(__dirname, 'fixtures');
-var badSource = path.join(fixturesDir, 'Bad.elm');
-var goodSource = path.join(fixturesDir, 'Good.elm');
-var goodDependency = path.join(fixturesDir, 'GoodDependency.elm');
-var elmPackage = path.join(fixturesDir, 'elm-package.json');
+const path = require('path');
+const crypto = require('crypto');
+const { assert } = require('chai');
+const compiler = require('node-elm-compiler');
+const loader = require('../index.js');
 
-var toString = Object.prototype.toString;
+const fixturesDir = path.join(__dirname, 'fixtures');
+const badSource = path.join(fixturesDir, 'Bad.elm');
+const goodSource = path.join(fixturesDir, 'Good.elm');
+const elmPackage = path.join(fixturesDir, 'elm-package.json');
 
-var isArray = function (obj) {
+const { toString } = Object.prototype;
+
+function isArray(obj) {
   return toString.call(obj) === '[object Array]';
-};
+}
 
-var hash = function (data) {
+function hash(data) {
   return crypto.createHash('md5').update(data).digest('hex');
-};
+}
 
-var compile = function (filename) {
-  return compiler.compileToString([filename], {yes: true, cwd: fixturesDir})
-    .then(function (data) {
-      return data.toString();
-    });
+function compile(filename) {
+  return compiler.compileToString([ filename ], {
+    yes: true,
+    cwd: fixturesDir
+  })
+    .then(data => data.toString());
 }
 
 // Mock of webpack's loader context.
-var mock = function (source, query, opts, callback, watchMode, cwd) {
-  var emittedError;
-  var emittedWarning;
-  var addedDependencies = [];
-  var addedDirDependencies = [];
+function mock(source, query, opts, callback, watchMode, cwd) {
+  let emittedError = null;
+  let emittedWarning = null;
+  const addedDependencies = [];
+  const addedDirDependencies = [];
 
-  var result = {
+  const result = {
     loaders: [],
     loaderIndex: 0,
 
     resource: source,
     resourcePath: source,
 
-    async: function () { return callback; },
+    async: () => callback,
 
-    emitError: function (err) { emittedError = err; },
-    emittedError: function () { return emittedError; },
-    emitWarning: function (warn) { emittedWarning = warn; },
-    emittedWarning: function () { return emittedWarning; },
+    emitError: err => {
+      emittedError = err;
+    },
+    emittedError: () => emittedError,
+    emitWarning: warn => {
+      emittedWarning = warn;
+    },
+    emittedWarning: () => emittedWarning,
 
-    addDependency: function (dep) { addedDependencies.push(dep); },
-    addContextDependency: function(dir) { addedDirDependencies.push(dir); },
-    addedDependencies: function () { return addedDependencies; },
-    addedDirDependencies: function() { return addedDirDependencies; },
+    addDependency: dep => {
+      addedDependencies.push(dep);
+    },
+    addContextDependency: dir => {
+      addedDirDependencies.push(dir);
+    },
+    addedDependencies: () => addedDependencies,
+    addedDirDependencies: () => addedDirDependencies,
 
-    cacheable: function () {},
+    cacheable: () => {},
 
     options: {}
   };
 
-  if (query) {
-    result.query = '?' + (isArray(query) ? query.join('&') : query);
+  if (isArray(query)) {
+    result.query = `?${query.join('&')}`;
+  } else if (query) {
+    result.query = `?${query}`;
   }
 
   if (opts) {
     result.options.elm = opts;
   }
 
-  if (cwd){
-    result.options.cwd = "./"
+  if (cwd) {
+    result.options.cwd = './';
   }
 
   if (watchMode) {
-    result.isInWatchMode = function() { return true; };
-    result.argv = {watch : true};
+    result.isInWatchMode = () => true;
+    result.argv = {
+      watch: true
+    };
   }
 
   return result;
-};
+}
 
-describe('sync mode', function () {
-  var context;
+describe('sync mode', () => {
+  let context = null;
 
-  it('throws', function () {
+  it('throws', () => {
     context = mock(goodSource);
 
-    assert.throw(function () {
+    assert.throw(() => {
       loader.call(context, goodSource);
     }, /currently only supports async mode/);
   });
 });
 
-describe('async mode', function () {
-  var context;
+describe('async mode', () => {
+  let context = null;
 
   // Download of Elm can take a while.
   this.timeout(600000);
 
-  it('compiles the resource', function (done) {
-    var options = {
+  it('compiles the resource', done => {
+    const options = {
       cwd: fixturesDir
     };
 
-    var callback = function (loaderErr, loaderResult) {
-      compile(goodSource).then(function (compilerResult) {
+    function callback(loaderErr, loaderResult) {
+      compile(goodSource).then(compilerResult => {
         assert.equal(hash(loaderResult), hash(compilerResult));
         done();
       });
-    };
+    }
 
     context = mock(goodSource, null, options, callback);
     loader.call(context, goodSource);
   });
 
-  it('does not add dependencies in normal mode', function (done) {
-    var options = {
+  it('does not add dependencies in normal mode', done => {
+    const options = {
       cwd: fixturesDir
     };
 
     process.argv = [];
-    var callback = function () {
+    function callback() {
       assert.equal(context.addedDependencies().length, 0);
       assert.equal(context.addedDirDependencies().length, 0);
       done();
-    };
+    }
 
     context = mock(goodSource, null, options, callback);
     loader.call(context, goodSource);
   });
 
-  it('does add dependencies in watch mode', function (done) {
-    var options = {
+  it('does add dependencies in watch mode', done => {
+    const options = {
       cwd: fixturesDir
     };
 
-    process.argv = [ "--watch" ];
-    var callback = function () {
+    process.argv = [ '--watch' ];
+    function callback() {
       assert.equal(context.addedDependencies().length, 2);
       assert.include(context.addedDependencies(), elmPackage);
       assert.equal(context.addedDirDependencies().length, 1);
       assert.include(context.addedDirDependencies(), fixturesDir);
       done();
-    };
+    }
 
     context = mock(goodSource, null, options, callback, true);
     loader.call(context, goodSource);
   });
 
-  it('emits warnings for unknown compiler options', function (done) {
-    var options = {
+  it('emits warnings for unknown compiler options', done => {
+    const options = {
       cwd: fixturesDir,
       foo: 'bar'
     };
 
-    var callback = function () {
+    function callback() {
       assert.match(context.emittedWarning(), /unknown Elm compiler option/i);
       done();
-    };
+    }
 
     context = mock(goodSource, null, options, callback);
     loader.call(context, goodSource);
   });
 
-  xit('emits errors for incorrect source files', function (done) {
-    var options = {
+  xit('emits errors for incorrect source files', done => {
+    const options = {
       cwd: fixturesDir
     };
 
-    var callback = function () {
+    function callback() {
       assert.match(context.emittedError(), /syntax problem/i);
       done();
-    };
+    }
 
     context = mock(badSource, null, options, callback);
     loader.call(context, badSource);
   });
-
 });

--- a/test/loader.js
+++ b/test/loader.js
@@ -104,7 +104,7 @@ describe('sync mode', () => {
   });
 });
 
-describe('async mode', () => {
+describe('async mode', function passContextFunc() {
   let context = null;
 
   // Download of Elm can take a while.


### PR DESCRIPTION
[ESLint](http://eslint.org/) added to loader.

I configure linter by only my experience (for ex: best practices and stylistic blocks) and I think that some rules can be changed.
I fixed linting issues in source code of loader, tests and example. I tried fix they without change of logic and I think that I succeded.
I also added `"lint"` script in `package.json`. By the way it does not use global `eslint`.
I added running lint to travis scripts before running tests.

I will waiting for review and I will be glad to discuss arisen questions.

#### UPD Mar 7th:

Version of node in travis and appveyor was set similar `package.json`.