### PR TITLE
Fix off-by-one bug in maxInstances

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = function() {
   }
 
   var intervalId = setInterval(function(){
-    if (runningInstances > maxInstances) return;
+    if (runningInstances >= maxInstances) return;
     runningInstances += 1;
     clearInterval(intervalId);
 


### PR DESCRIPTION
Previous implementation would spawn a new Elm compiler process even if we had
already reached the configured maximum number of instances, as long as we had
not already _exceeded_ that maximum. In effect, maxInstances would always be
taken to be 1 greater than intended.