### PR TITLE
Update usage instructions for Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ $ npm install --save elm-webpack-loader
 
 ## Usage
 
-[Documentation: Using loaders](https://webpack.js.org/configuration/module/#rule)
+#### Webpack 2
 
-In your `webpack.config.js` file:
+Documentation: [rules](https://webpack.js.org/configuration/module/#rule)
+
+`webpack.config.js`:
 
 ```js
 module.exports = {
@@ -26,7 +28,28 @@ module.exports = {
     rules: [{
       test: /\.elm$/,
       exclude: [/elm-stuff/, /node_modules/],
-      use: 'elm-webpack-loader'
+      use: {
+        loader: 'elm-webpack-loader',
+        options: {}
+      }
+    }]
+  }
+};
+```
+
+#### Webpack 1
+
+Documentation: [loaders](http://webpack.github.io/docs/using-loaders.html)
+
+`webpack.config.js`:
+
+```js
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.elm$/,
+      exclude: [/elm-stuff/, /node_modules/],
+      loader: 'elm-webpack'
     }]
   }
 };

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ $ npm install --save elm-webpack-loader
 
 ## Usage
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+[Documentation: Using loaders](https://webpack.js.org/configuration/module/#rule)
 
 In your `webpack.config.js` file:
 
 ```js
 module.exports = {
   module: {
-    loaders: [{
+    rules: [{
       test: /\.elm$/,
       exclude: [/elm-stuff/, /node_modules/],
-      loader: 'elm-webpack'
+      use: 'elm-webpack-loader'
     }]
   }
 };


### PR DESCRIPTION
There is now a Webpack 1 [deprecation warning](http://webpack.github.io/docs/using-loaders.html) at the top of the old link and not using the full `elm-webpack-loader` name throws an error.

```
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'elm-webpack-loader' instead of 'elm-webpack',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
```