### PR TITLE
Upgrade to webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Elm loader [![Version](https://img.shields.io/npm/v/elm-webpack-loader.svg)](https://www.npmjs.com/package/elm-webpack-loader) [![Travis build Status](https://travis-ci.org/elm-community/elm-webpack-loader.svg?branch=master)](http://travis-ci.org/elm-community/elm-webpack-loader) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/7a5ws36eenwpdvgc/branch/master?svg=true)](https://ci.appveyor.com/project/elm-community/elm-webpack-loader/branch/master)
 
-[Webpack](http://webpack.github.io/docs/) loader for the [Elm](http://elm-lang.org/) programming language.
+[Webpack](https://webpack.js.org/) loader for the [Elm](http://elm-lang.org/) programming language.
 
 It is aware of Elm dependencies and tracks them. This means that in `--watch`
-mode, if you `require` an Elm module from a Webpack entry point, not only will
+mode, if you `require` an Elm module from a webpack entry point, not only will
 that `.elm` file be watched for changes, but any other Elm modules it imports will
 be watched for changes as well.
 
@@ -16,17 +16,17 @@ $ npm install --save elm-webpack-loader
 
 ## Usage
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+[Documentation: Using loaders](https://webpack.js.org/loaders/)
 
 In your `webpack.config.js` file:
 
 ```js
 module.exports = {
   module: {
-    loaders: [{
+    rules: [{
       test: /\.elm$/,
       exclude: [/elm-stuff/, /node_modules/],
-      loader: 'elm-webpack'
+      use: 'elm-webpack-loader'
     }]
   }
 };
@@ -42,12 +42,14 @@ You can add `cwd=elmSource` to the loader:
 ```js
 var elmSource = __dirname + '/elm/path/in/project'
   ...
-  loader: 'elm-webpack?cwd=' + elmSource
+  use: 'elm-webpack-loader?cwd=' + elmSource
   ...
 ```
 
 You can use this to specify a custom location within your project for your elm files. Note, this
-will cause the compiler to look for **all** elm source files in the specified directory. This approach is recommended as it allows the compile to watch elm-package.json as well as every file in the source directories.
+will cause the compiler to look for **all** elm source files in the specified directory. This
+approach is recommended as it allows the compile to watch elm-package.json as well as every file
+in the source directories.
 
 #### maxInstances (default 1)
 
@@ -55,11 +57,13 @@ You can add `maxInstances=8` to the loader:
 
 ```js
   ...
-  loader: 'elm-webpack?maxInstances=8'
+  use: 'elm-webpack-loader?maxInstances=8'
   ...
 ```
 
-Set a limit to the number of maxInstances of elm that can spawned. This should be set to a number less than the number of cores your machine has. The ideal number is 1, as it will prevent Elm instances causing deadlocks. 
+Set a limit to the number of maxInstances of elm that can spawned. This should be set to a number
+less than the number of cores your machine has. The ideal number is 1, as it will prevent Elm
+instances causing deadlocks.
 
 #### Cache (default false)
 
@@ -67,7 +71,7 @@ You can add `cache=true` to the loader:
 
 ```js
   ...
-  loader: 'elm-webpack?cache=true'
+  use: 'elm-webpack-loader?cache=true'
   ...
 ```
 
@@ -85,21 +89,23 @@ wants to force this behaviour you can add `forceWatch=true` to the loader:
 
 ```js
   ...
-  loader: 'elm-webpack?forceWatch=true'
+  use: 'elm-webpack-loader?forceWatch=true'
   ...
 ```
 
 #### Upstream options
 
-All options are sent down as an `options` object to node-elm-compiler. For example, you can explicitly pick the local `elm-make` binary by setting the option `pathToMake`:
+All options are sent down as an `options` object to node-elm-compiler. For example, you can
+explicitly pick the local `elm-make` binary by setting the option `pathToMake`:
 
 ```js
   ...
-  loader: 'elm-webpack?pathToMake=node_modules/.bin/elm-make',
+  use: 'elm-webpack-loader?pathToMake=node_modules/.bin/elm-make',
   ...
 ```
 
-For a list all possible options, [consult the source](https://github.com/rtfeldman/node-elm-compiler/blob/3fde73d/index.js#L12-L23).
+For a list all possible options,
+[consult the source](https://github.com/rtfeldman/node-elm-compiler/blob/3fde73d/index.js#L12-L23).
 
 ## Notes
 
@@ -122,11 +128,13 @@ For a full featured example project that uses elm-webpack-loader see [pmdesgn/el
 ### noParse
 
 Webpack can complain about precompiled files (files compiled by `elm-make`).
-You can silence this warning with [noParse](https://webpack.github.io/docs/configuration.html#module-noparse). You can see it in use in the example.
+You can silence this warning with
+[noParse](https://webpack.github.io/docs/configuration.html#module-noparse). You can see it in use
+in the example.
 
 ```js
   module: {
-    loaders: [...],
+    rules: [...],
     noParse: [/.elm$/]
   }
 ```
@@ -137,7 +145,7 @@ You can silence this warning with [noParse](https://webpack.github.io/docs/confi
 ### 4.3.0
 
 - Set maxInstances to 1
-- Patch watching behaviour 
+- Patch watching behaviour
 - Add `forceWatch` to force watch mode
 
 ### 4.2.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Webpack](https://webpack.js.org/) loader for the [Elm](http://elm-lang.org/) programming language.
 
 It is aware of Elm dependencies and tracks them. This means that in `--watch`
-mode, if you `require` an Elm module from a webpack entry point, not only will
+mode, if you `require` an Elm module from a Webpack entry point, not only will
 that `.elm` file be watched for changes, but any other Elm modules it imports will
 be watched for changes as well.
 
@@ -65,7 +65,12 @@ You can add `cwd=elmSource` to the loader:
 ```js
 var elmSource = __dirname + '/elm/path/in/project'
   ...
-  use: 'elm-webpack-loader?cwd=' + elmSource
+  use: {
+    loader: 'elm-webpack-loader',
+    options: {
+      cwd: elmSource
+    }
+  }
   ...
 ```
 
@@ -80,7 +85,12 @@ You can add `maxInstances=8` to the loader:
 
 ```js
   ...
-  use: 'elm-webpack-loader?maxInstances=8'
+  use: {
+    loader: 'elm-webpack-loader',
+    options: {
+      maxInstances: 8
+    }
+  }
   ...
 ```
 
@@ -94,25 +104,35 @@ You can add `cache=true` to the loader:
 
 ```js
   ...
-  use: 'elm-webpack-loader?cache=true'
+  use: {
+    loader: 'elm-webpack-loader',
+    options: {
+      cache: true
+    }
+  }
   ...
 ```
 
-If you add this, when using `npm run watch`, the loader will only load the
-dependencies at startup. This could be performance improvement, but know that
-new files won't be picked up and so won't be watched until you restart webpack.
+If you add this, when using `npm run watch`, the loader will only load the dependencies at startup.
+This could be performance improvement, but know that new files won't be picked up and so won't be
+watched until you restart webpack.
 
 This flag doesn't matter if you don't use watch mode.
 
 #### ForceWatch (default false)
 
-This loader will infer if you are running webpack in watch mode by checking
-the webpack arguments. If you are running webpack programmatically and
-wants to force this behaviour you can add `forceWatch=true` to the loader:
+This loader will infer if you are running webpack in watch mode by checking the webpack arguments.
+If you are running webpack programmatically and wants to force this behaviour you can add
+`forceWatch=true` to the loader:
 
 ```js
   ...
-  use: 'elm-webpack-loader?forceWatch=true'
+  use: {
+    loader: 'elm-webpack-loader',
+    options: {
+      forceWatch: true
+    }
+  }
   ...
 ```
 
@@ -123,7 +143,12 @@ explicitly pick the local `elm-make` binary by setting the option `pathToMake`:
 
 ```js
   ...
-  use: 'elm-webpack-loader?pathToMake=node_modules/.bin/elm-make',
+  use: {
+    loader: 'elm-webpack-loader',
+    options: {
+      pathToMake: 'node_modules/.bin/elm-make'
+    }
+  }
   ...
 ```
 

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "dev": "webpack-dev-server --port 3000"
   },
   "dependencies": {
-    "file-loader": "^0.9.0",
-    "webpack": "^1.12.0",
-    "webpack-dev-server": "^1.14.0"
+    "file-loader": "^0.11.1",
+    "webpack": "^2.5.1",
+    "webpack-dev-server": "^2.4.5"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -2,26 +2,25 @@ module.exports = {
   entry: './src/index.js',
 
   output: {
-    path: './dist',
+    path: __dirname + '/dist',
     filename: 'index.js'
   },
 
   resolve: {
-    modulesDirectories: ['node_modules'],
-    extensions: ['', '.js', '.elm']
+    extensions: ['.js', '.elm']
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.html$/,
         exclude: /node_modules/,
-        loader: 'file?name=[name].[ext]'
+        use: 'file-loader?name=[name].[ext]'
       },
       {
         test: /\.elm$/,
         exclude: [/elm-stuff/, /node_modules/],
-        loader: '../../index.js'
+        use: '../index.js'
       }
     ],
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -15,12 +15,19 @@ module.exports = {
       {
         test: /\.html$/,
         exclude: /node_modules/,
-        use: 'file-loader?name=[name].[ext]'
+        use: {
+          loader: 'file-loader',
+          options: {
+            name: '[name].[ext]'
+          }
+        }
       },
       {
         test: /\.elm$/,
         exclude: [/elm-stuff/, /node_modules/],
-        use: '../index.js'
+        use: {
+          loader: '../index.js'
+        }
       }
     ],
 

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "glob": "^7.1.1",
     "loader-utils": "^1.0.2",
     "node-elm-compiler": "^4.2.1",
-    "yargs": "^8.0.1"
+    "yargs": "^6.5.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "mocha": "^3.3.0"
+    "mocha": "3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "glob": "^7.1.1",
     "loader-utils": "^1.0.2",
     "node-elm-compiler": "^4.2.1",
-    "yargs": "^6.5.0"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "mocha": "3.0.2"
+    "mocha": "^3.3.0"
   }
 }


### PR DESCRIPTION
What's changed: 

- Upgrade dependancies to the latest versions
- Update README.md to be webpack 2 compatible 
- Update the example to work with webpack 2.x.x
- Minor README.md cleanup (mainly line lengths limits)

