### PR TITLE
[WIP] Add support for multiple modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can add `maxInstances=8` to the loader:
   ...
 ```
 
-Set a limit to the number of maxInstances of elm that can spawned. This should be set to a number less than the number of cores your machine has. The ideal number is 1, as it will prevent Elm instances causing deadlocks. 
+Set a limit to the number of maxInstances of elm that can spawned. This should be set to a number less than the number of cores your machine has. The ideal number is 1, as it will prevent Elm instances causing deadlocks.
 
 #### Cache (default false)
 
@@ -110,6 +110,75 @@ wants to force this behaviour you can add `forceWatch=true` to the loader:
   ...
   loader: 'elm-webpack?forceWatch=true'
   ...
+```
+
+#### Files (default - path to 'required' file)
+
+elm-make allows you to specify multiple modules to be combined into a single bundle
+
+```
+elm-make Main.elm Path/To/OtherModule.elm --output=combined.js
+```
+
+The `files` option allows you to do the same within webpack
+
+```
+module: {
+  loaders: [
+    {
+      test: /\.elm$/,
+      exclude: [/elm-stuff/, /node_modules/],
+      loader: "elm-webpack",
+      options: {
+        files: [
+          path.resolve(__dirname, "path/to/Main.elm"),
+          path.resolve(__dirname, "Path/To/OtherModule.elm")
+        ]
+      }
+    }
+  ]
+}
+```
+(Note: It's only possible to pass array options when using the object style of loader configuration.)
+
+You're then able to use this with
+
+```
+import Elm from "./elm/Main";
+
+Elm.Main.embed(document.getElementById("main"));
+Elm.Path.To.OtherModule.embed(document.getElementById("other"));
+```
+
+##### Modules with elm-hot
+
+Because you must use the object style configuration it isn't possible to use the chained loader syntax (`loader:  'elm-hot!elm-webpack'`). Instead you may use [`webpack-combine-loaders`](https://www.npmjs.com/package/webpack-combine-loaders)
+
+```
+var combineLoaders = require("webpack-combine-loaders");
+
+module: {
+  loaders: [
+    {
+      test: /\.elm$/,
+      exclude: [/elm-stuff/, /node_modules/],
+      loader: combineLoaders([
+        {
+          loader: "elm-hot"
+        },
+        {
+          loader: "elm-webpack",
+          options: {
+            files: [
+              path.resolve(__dirname, "path/to/Main.elm"),
+              path.resolve(__dirname, "Path/To/OtherModule.elm")
+            ]
+          }
+        }
+      ])
+    }
+  ]
+}
 ```
 
 #### Upstream options
@@ -163,7 +232,7 @@ You can silence this warning with [noParse](https://webpack.github.io/docs/confi
 ### 4.3.0
 
 - Set maxInstances to 1
-- Patch watching behaviour 
+- Patch watching behaviour
 - Add `forceWatch` to force watch mode
 
 ### 4.2.0

--- a/index.js
+++ b/index.js
@@ -15,8 +15,22 @@ var defaultOptions = {
   yes: true
 };
 
-var getInput = function() {
-  return this.resourcePath;
+var getFiles = function(options) {
+  var basepath = path.dirname(this.resourcePath);
+  var files = options && options.files;
+
+  if (files === undefined) return [this.resourcePath];
+
+  if (!Array.isArray(files)) {
+    throw new Error('files option must be an array');
+  }
+
+  if (files.length === 0) {
+    throw new Error("You specified the 'files' option but didn't list any files");
+  }
+
+  delete options.files;
+  return files;
 };
 
 var getOptions = function() {
@@ -67,6 +81,20 @@ var filesToWatch = function(cwd){
   return paths;
 };
 
+var dependenciesFor = function(resourcePath, files) {
+  return findAllDependencies(files)
+    .then(function (dependencies) {
+      return unique(dependencies.concat(remove(resourcePath, files)));
+    });
+}
+
+var findAllDependencies = function(files) {
+  return Promise.all(files.map(
+    function(f) { return elmCompiler.findAllDependencies(f) }
+  ))
+  .then(flatten);
+}
+
 module.exports = function() {
   this.cacheable && this.cacheable();
 
@@ -80,8 +108,9 @@ module.exports = function() {
   var addDirDependency = _addDirDependency.bind(this);
   var emitError = this.emitError.bind(this);
 
-  var input = getInput.call(this);
   var options = getOptions.call(this);
+  var files = getFiles.call(this, options);
+  var resourcePath = this.resourcePath;
 
   var promises = [];
 
@@ -100,7 +129,7 @@ module.exports = function() {
 
     // find all the deps, adding them to the watch list if we successfully parsed everything
     // otherwise return an error which is currently ignored
-    var dependencies = elmCompiler.findAllDependencies(input).then(function(dependencies){
+    var dependencies = dependenciesFor(resourcePath, files).then(function(dependencies){
       // add each dependency to the tree
       dependencies.map(addDependencies);
       return { kind: 'success', result: true };
@@ -130,11 +159,11 @@ module.exports = function() {
     // If we are running in watch mode, and we have previously compiled
     // the current file, then let the user know that elm-make is running
     // and can be slow
-    if (alreadyCompiledFiles.indexOf(input) > -1){
+    if (alreadyCompiledFiles.indexOf(resourcePath) > -1){
       console.log('Started compiling Elm..');
     }
 
-    var compilation = elmCompiler.compileToString(input, options)
+    var compilation = elmCompiler.compileToString(files, options)
       .then(function(v) { runningInstances -= 1; return { kind: 'success', result: v }; })
       .catch(function(v) { runningInstances -= 1; return { kind: 'error', error: v }; });
 
@@ -145,7 +174,7 @@ module.exports = function() {
         var output = results[results.length - 1]; // compilation output is always last
 
         if (output.kind == 'success') {
-          alreadyCompiledFiles.push(input);
+          alreadyCompiledFiles.push(resourcePath);
           callback(null, output.result);
         } else {
           output.error.message = 'Compiler process exited with error ' + output.error.message;
@@ -156,4 +185,25 @@ module.exports = function() {
       });
 
   }, 200);
+}
+
+
+// HELPERS
+
+function flatten(arrayOfArrays) {
+  return arrayOfArrays.reduce(function(flattened, array) {
+    return flattened.concat(array)
+  }, []);
+}
+
+function unique(items) {
+  return items.filter(function(item, index, array) {
+    return array.indexOf(item) === index;
+  });
+}
+
+function remove(condemned, items) {
+  return items.filter(function(item) {
+    return item !== condemned;
+  });
 }


### PR DESCRIPTION
This enables a `modules` option to be provided in the webpack config file, allowing the `elm-make` output to consist of multiple elm modules.