### PR TITLE
Identify watch mode when started with the stdin flag Fixes #122

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ var _addDirDependency = function(dirs){
   dirs.forEach(this.addContextDependency.bind(this));
 };
 
+var isFlagSet = function(args, flag) {
+  return typeof args[flag] !== "undefined" && args[flag];
+};
+
 /* Figures out if webpack has been run in watch mode
     This currently means either that the `watch` command was used
     Or it was run via `webpack-dev-server`
@@ -43,15 +47,17 @@ var isInWatchMode = function(){
   // parse the argv given to run this webpack instance
   var argv = yargs(process.argv)
       .alias('w', 'watch')
+      .alias('stdin', 'watch-stdin')
       .argv;
 
-  var hasWatchArg = typeof argv.watch !== "undefined" && argv.watch;
+  var hasWatchArg = isFlagSet(argv, 'watch');
+  var hasStdinArg = isFlagSet(argv, 'watch-stdin');
 
   var hasWebpackDevServer = Array.prototype.filter.call(process.argv, function (arg) {
     return arg.indexOf('webpack-dev-server') !== -1;
   }).length > 0;
 
-  return hasWebpackDevServer || hasWatchArg;
+  return hasWebpackDevServer || hasWatchArg || hasStdinArg;
 };
 
 /* Takes a working dir, tries to read elm-package.json, then grabs all the modules from in there


### PR DESCRIPTION
This PR adds support for the `--watch-stdin` flag. Before this point, the loader was only checking for the `--watch` flag or a call to `webpack-dev-server`. I would be happy to write a test for this, but I'm not sure this change is worth another integration test, and from what I'm seeing writing a unit test would require some slight reworking.

Other trivia that came up: The webpack-cli actually documents [five watch flags](https://webpack.js.org/api/cli/#watch-options) that could be set. The `--save` flag has probably been completely removed from an earlier version, because I can't find any other evidence that it still exists. If my reading of [these lines](https://github.com/webpack/webpack-cli/blob/056d4700a056afdd730ecd2ba22c24c73e1a0f0c/bin/convert-argv.js#L171-L192) is correct then the `--watch-poll` and `--watch-aggregate-timeout` flags both set watch options, but don't trigger watch mode itself. That leaves us with just the `--watch` and `--watch-stdin` flags to support, both of which do trigger watch mode.