### PR TITLE
Allow files option to customise default files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ var getFiles = function(options) {
   }
 
   delete options.files;
+  
+  if (options.appendFilesToExisting) {
+    files.push(this.resourcePath);
+  }
+
   return files;
 };
 


### PR DESCRIPTION
Hi!
I'd like to be able to add files to the existing "default" file set, so I'm proposing adding a flag to options to enable this. My use case is I want to add an environment specific file `env/{env}/Env.elm` to customise API endpoints etc for dev/test/prod, but I also want the current autoload behaviour to be left alone.