### PR TITLE
Fix embed code in examples

### DIFF
--- a/example-wp2/src/index.js
+++ b/example-wp2/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main');
+var Elm = require('./Main.elm').Elm;
 
-Elm.Main.embed(document.getElementById('main'));
+Elm.Main.init({
+  node: document.getElementById('main')
+});

--- a/example-wp4/src/index.js
+++ b/example-wp4/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main.elm');
+var Elm = require('./Main.elm').Elm;
 
-Elm.Main.embed(document.getElementById('main'));
+Elm.Main.init({
+  node: document.getElementById('main')
+});

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main');
+var Elm = require('./Main.elm').Elm;
 
-Elm.Main.embed(document.getElementById('main'));
+Elm.Main.init({
+  node: document.getElementById('main')
+});
+


### PR DESCRIPTION
Fixes #149 

Found this was a problem in each of the examples I tested.

I explored modifying the parameters sent to `elm make` to see if there was a way to compile a Elm module as a library (so that we could write `var Elm = require('./src/Main.elm')` rather than having to use a property of the import `var Elm = require('./src/Main.elm').Elm`), but I was unable to find any such option.