### PR TITLE
Update Readme to use string array runtimeOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ with some additional flags to give it more memory, `e.g. -A128M -H128M -n8m`.
   use: {
     loader: 'elm-webpack-loader',
     options: {
-      runtimeOptions: '-A128M -H128M -n8m'
+      runtimeOptions: ['-A128M', '-H128M', '-n8m']
     }
   }
   ...


### PR DESCRIPTION
`node-elm-compiler` expects a string array.

<https://github.com/rtfeldman/node-elm-compiler/blob/48f29fc243e149ad6f8ee0c6ef740d998764cf55/test/compile.js#L57>