### PR TITLE
Remove elm dependency 😱

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ os:
 
 env:
   matrix:
-    - ELM_VERSION=0.19 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.19 TARGET_NODE_VERSION=4.2
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=8
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=10
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=11
+    - ELM_VERSION=0.19.0-no-deps TARGET_NODE_VERSION=12
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/package.json
+++ b/package.json
@@ -25,14 +25,13 @@
   },
   "homepage": "https://github.com/elm-community/elm-webpack-loader",
   "dependencies": {
-    "elm": "^0.19.0",
     "glob": "^7.1.1",
     "loader-utils": "^1.0.2",
     "node-elm-compiler": "^5.0.0",
     "yargs": "^6.5.0"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "mocha": "3.0.2"
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4"
   }
 }


### PR DESCRIPTION
Initially I planned to make a PR to require Elm version `0.19.0-no-deps` (and there's actually #172 which does exactly that), because `0.19.0` has a few external dependencies, and some of them are outdated. Unfortunately, `0.19.0` seems to be greater than `0.19.0-no-deps`, so with current setup there was no way to avoid `0.19.0` installation.

But then I though that maybe we should let user decide which elm version to use. E.g. `0.19.0` will still work for those using nodeJS 6. Some other packages do the same, for example `sass-loader` requires user to install sass compiler they want.

This will require major version bump I guess.

Also this PR upgraded vulnerable mocha package, and updates travis config to test only against maintained nodejs versions (8, 10, 11, 12).

This also fixes:
#171 - deps updated
#170 - installing 0.19.0-no-deps will fix it for them; and installing elm-webpack-loader won't cause `0.19.0` version to be installed with this PR (or #172)