### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ You're then able to use this with
 ```js
 import Elm from "./elm/Main";
 
-Elm.Main.embed(document.getElementById("main"));
-Elm.Path.To.OtherModule.embed(document.getElementById("other"));
+Elm.Main.init({node: document.getElementById("main")});
+Elm.Path.To.OtherModule.init({node: document.getElementById("other")});
 ```
 
 ##### Modules with elm-hot

--- a/example-wp2/src/index.js
+++ b/example-wp2/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 require('./index.html');
-var elm = require('./Main');
+var Elm = require('./Main').Elm;
 
-var app = elm.Elm.Main.init({
+var app = Elm.Main.init({
   node: document.getElementById('main')
 });

--- a/example-wp2/src/index.js
+++ b/example-wp2/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main');
+var elm = require('./Main');
 
-Elm.Main.embed(document.getElementById('main'));
+var app = elm.Elm.Main.init({
+  node: document.getElementById('main')
+});

--- a/example-wp4/src/index.js
+++ b/example-wp4/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main.elm');
+var elm = require('./Main.elm');
 
-Elm.Main.embed(document.getElementById('main'));
+var app = elm.Elm.Main.init({
+  node: document.getElementById('main')
+});

--- a/example-wp4/src/index.js
+++ b/example-wp4/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 require('./index.html');
-var elm = require('./Main.elm');
+var Elm = require('./Main.elm').Elm;
 
-var app = elm.Elm.Main.init({
+var app = Elm.Main.init({
   node: document.getElementById('main')
 });

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 require('./index.html');
-var elm = require('./Main');
+var Elm = require('./Main').Elm;
 
-var app = elm.Elm.Main.init({
+var app = Elm.Main.init({
   node: document.getElementById('main')
 });

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./Main');
+var elm = require('./Main');
 
-Elm.Main.embed(document.getElementById('main'));
+var app = elm.Elm.Main.init({
+  node: document.getElementById('main')
+});


### PR DESCRIPTION
The JavaScript method to init an HTML node in Elm 0.19 is
different to Elm 0.18.