### PR TITLE
Empty the error stacktrace

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,7 @@ module.exports = function() {
           }
 
           output.error.message = 'Compiler process exited with error ' + output.error.message;
+          output.error.stack = null;
           callback(output.error);
         }
       }).catch(function(err){


### PR DESCRIPTION
The stacktrace emitted by elm-webpack-loader is mostly useless (at least I don't know of an usecase where it would be benefitial) - this PR clears it.

# Before
![err_before](https://user-images.githubusercontent.com/149425/69959457-8182aa80-1507-11ea-9d73-211b81d46004.png)

# After
![err_after](https://user-images.githubusercontent.com/149425/69959462-834c6e00-1507-11ea-84da-4c3a38a258ef.png)
