### PR TITLE
Send build output to stdout and retain formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ in the example.
 
 ## Revisions
 
+### 6.0.2
+
+- Logs build output directly to stdout to retain formatting
+
 ### 6.0.0
 
 - Elm is now a peer dependency.

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var defaultOptions = {
 };
 
 var getFiles = function(options) {
-  var basepath = path.dirname(this.resourcePath);
   var files = options && options.files;
 
   if (files === undefined) return [this.resourcePath];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-webpack-loader",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This patch fixes it so that any elm compilation errors are formatted correctly (using correct colours, etc) instead of logging the entire message as an error (all formatted with red text).