### PR TITLE
Add temp as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-webpack-loader",
-  "version": "7.0.2",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -457,7 +457,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
       "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -844,10 +843,11 @@
       }
     },
     "temp": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
-      "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "requires": {
+        "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/elm-community/elm-webpack-loader",
   "dependencies": {
     "loader-utils": "^2.0.0",
-    "node-elm-compiler": "^5.0.0"
+    "node-elm-compiler": "^5.0.0",
+    "temp": "^0.9.4"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
See https://github.com/elm-community/elm-webpack-loader/issues/200

"temp" is in the package-lock.json
But when running this without elm-test in the same project I get this issue above

```
Error: Cannot find module 'temp'
```

As `temp` is used directly here:
https://github.com/elm-community/elm-webpack-loader/blob/2bbe487e654231e3531374747c23043b8f440a44/index.js#L5

I believe it should be as a direct dependecy in package.json

Thanks